### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Sebastian Kraus <sekdiy@gmail.com>
 maintainer=Sebastian Kraus <sekdiy@gmail.com>
 sentence=An Arduino flow meter library that provides calibrated liquid flow and volume measurement with flow sensors.
 paragraph=This Flow Meter library is primarily intended for use with impeller flow sensors, although other types of sensors could be made to work.
-category=Device Control Sensors Sensor Measurement Liquid Water Flow Meter
+category=Sensors
 url=https://github.com/sekdiy/FlowMeter
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Device Control Sensors Sensor Measurement Liquid Water Flow Meter' in library FlowMeter is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

## Tackles issue #

Fixes https://github.com/sekdiy/FlowMeter/issues/3

## changes being applied by this pull request

- Change to valid `category` value in library.properties

## people involved

@per1234/FlowMeter

CC: @Gr3yh0und