### PR TITLE
Modify interrupts to be more portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 *.exe
 *.out
 *.app
+
+.vscode

--- a/examples/Calibration/Calibration.ino
+++ b/examples/Calibration/Calibration.ino
@@ -2,7 +2,7 @@
 
 // enter your own sensor properties here, including calibration points
 FlowSensorProperties MySensor = {60.0f, 5.5f, {1, 1, 1, 1, 1, 1, 1, 1, 1, 1}};
-FlowMeter Meter = FlowMeter(2, MySensor);
+FlowMeter *Meter;
 
 // timekeeping variables
 long period = 1000;   // one second (in milliseconds)
@@ -11,7 +11,7 @@ long lastTime = 0;
 // define an 'interrupt service routine' (ISR)
 void MeterISR() {
     // let our flow meter count the pulses
-    Meter.count();
+    Meter->count();
 }
 
 void setup() {
@@ -19,10 +19,10 @@ void setup() {
     Serial.begin(9600);
 
     // enable a call to the 'interrupt service handler' (ISR) on every rising edge at the interrupt pin
-    attachInterrupt(INT0, MeterISR, RISING);
+    Meter = new FlowMeter(2, MySensor, MeterISR, RISING);
 
     // sometimes initializing the gear generates some pulses that we should ignore
-    Meter.reset();
+    Meter->reset();
 }
 
 void loop() {
@@ -34,13 +34,13 @@ void loop() {
     if (duration >= period) {
 
         // process the counted ticks
-        Meter.tick(duration);
+        Meter->tick(duration);
 
         // output some measurement result
-        Serial.println("FlowMeter - current flow rate: " + String(Meter.getCurrentFlowrate()) + " l/min, " +
-                       "nominal volume: " + String(Meter.getTotalVolume()) + " l, " +
-                       "compensated error: " + String(Meter.getCurrentError()) + " %, " +
-                       "duration: " + String(Meter.getTotalDuration() / 1000) + " s.");
+        Serial.println("FlowMeter - current flow rate: " + String(Meter->getCurrentFlowrate()) + " l/min, " +
+                       "nominal volume: " + String(Meter->getTotalVolume()) + " l, " +
+                       "compensated error: " + String(Meter->getCurrentError()) + " %, " +
+                       "duration: " + String(Meter->getTotalDuration() / 1000) + " s.");
 
         // prepare for next cycle
         lastTime = currentTime;

--- a/examples/Calibration/Calibration.ino
+++ b/examples/Calibration/Calibration.ino
@@ -19,7 +19,7 @@ void setup() {
     Serial.begin(9600);
 
     // enable a call to the 'interrupt service handler' (ISR) on every rising edge at the interrupt pin
-    Meter = new FlowMeter(2, MySensor, MeterISR, RISING);
+    Meter = new FlowMeter(digitalPinToInterrupt(2), MySensor, MeterISR, RISING);
 
     // sometimes initializing the gear generates some pulses that we should ignore
     Meter->reset();

--- a/examples/Multi/Multi.ino
+++ b/examples/Multi/Multi.ino
@@ -1,8 +1,8 @@
 #include <FlowMeter.h>  // https://github.com/sekdiy/FlowMeter
 
 // connect a flow meter to an interrupt pin (see notes on your Arduino model for pin numbers)
-FlowMeter Meter1 = FlowMeter(2);
-FlowMeter Meter2 = FlowMeter(3);
+FlowMeter *Meter1;
+FlowMeter *Meter2;
 
 // set the measurement update period to 1s (1000 ms)
 const unsigned long period = 1000;
@@ -10,13 +10,13 @@ const unsigned long period = 1000;
 // define an 'interrupt service handler' (ISR) for every interrupt pin you use
 void Meter1ISR() {
     // let our flow meter count the pulses
-    Meter1.count();
+    Meter1->count();
 }
 
 // define an 'interrupt service handler' (ISR) for every interrupt pin you use
 void Meter2ISR() {
     // let our flow meter count the pulses
-    Meter2.count();
+    Meter2->count();
 }
 
 void setup() {
@@ -25,12 +25,12 @@ void setup() {
 
     // enable a call to the 'interrupt service handler' (ISR) on every rising edge at the interrupt pin
     // do this setup step for every ISR you have defined, depending on how many interrupts you use
-    attachInterrupt(INT0, Meter1ISR, RISING);
-    attachInterrupt(INT1, Meter2ISR, RISING);
+    Meter1 = new FlowMeter(2, UncalibratedSensor, Meter1ISR, RISING);
+    Meter2 = new FlowMeter(2, UncalibratedSensor, Meter2ISR, RISING);
 
     // sometimes initializing the gear generates some pulses that we should ignore
-    Meter1.reset();
-    Meter2.reset();
+    Meter1->reset();
+    Meter2->reset();
 }
 
 void loop() {
@@ -38,12 +38,12 @@ void loop() {
     delay(period);
 
     // process the (possibly) counted ticks
-    Meter1.tick(period);
-    Meter2.tick(period);
+    Meter1->tick(period);
+    Meter2->tick(period);
 
     // output some measurement result
-    Serial.println("Meter 1 currently " + String(Meter1.getCurrentFlowrate()) + " l/min, " + String(Meter1.getTotalVolume())+ " l total.");
-    Serial.println("Meter 2 currently " + String(Meter2.getCurrentFlowrate()) + " l/min, " + String(Meter2.getTotalVolume())+ " l total.");
+    Serial.println("Meter 1 currently " + String(Meter1->getCurrentFlowrate()) + " l/min, " + String(Meter1->getTotalVolume())+ " l total.");
+    Serial.println("Meter 2 currently " + String(Meter2->getCurrentFlowrate()) + " l/min, " + String(Meter2->getTotalVolume())+ " l total.");
 
     //
     // any other code can go here

--- a/examples/Multi/Multi.ino
+++ b/examples/Multi/Multi.ino
@@ -25,8 +25,8 @@ void setup() {
 
     // enable a call to the 'interrupt service handler' (ISR) on every rising edge at the interrupt pin
     // do this setup step for every ISR you have defined, depending on how many interrupts you use
-    Meter1 = new FlowMeter(2, UncalibratedSensor, Meter1ISR, RISING);
-    Meter2 = new FlowMeter(2, UncalibratedSensor, Meter2ISR, RISING);
+    Meter1 = new FlowMeter(digitalPinToInterrupt(2), UncalibratedSensor, Meter1ISR, RISING);
+    Meter2 = new FlowMeter(digitalPinToInterrupt(3), UncalibratedSensor, Meter2ISR, RISING);
 
     // sometimes initializing the gear generates some pulses that we should ignore
     Meter1->reset();

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -16,7 +16,7 @@ void setup() {
     // prepare serial communication
     Serial.begin(9600);
 
-    Meter = new FlowMeter(2, UncalibratedSensor, MeterISR, RISING);
+    Meter = new FlowMeter(digitalPinToInterrupt(2), UncalibratedSensor, MeterISR, RISING);
 
     // sometimes initializing the gear generates some pulses that we should ignore
     Meter->reset();

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -1,7 +1,7 @@
 #include <FlowMeter.h>  // https://github.com/sekdiy/FlowMeter
 
 // connect a flow meter to an interrupt pin (see notes on your Arduino model for pin numbers)
-FlowMeter Meter = FlowMeter(2);
+FlowMeter *Meter;
 
 // set the measurement update period to 1s (1000 ms)
 const unsigned long period = 1000;
@@ -9,19 +9,17 @@ const unsigned long period = 1000;
 // define an 'interrupt service handler' (ISR) for every interrupt pin you use
 void MeterISR() {
     // let our flow meter count the pulses
-    Meter.count();
+    Meter->count();
 }
 
 void setup() {
     // prepare serial communication
     Serial.begin(9600);
 
-    // enable a call to the 'interrupt service handler' (ISR) on every rising edge at the interrupt pin
-    // do this setup step for every ISR you have defined, depending on how many interrupts you use
-    attachInterrupt(INT0, MeterISR, RISING);
+    Meter = new FlowMeter(2, UncalibratedSensor, MeterISR, RISING);
 
     // sometimes initializing the gear generates some pulses that we should ignore
-    Meter.reset();
+    Meter->reset();
 }
 
 void loop() {
@@ -29,10 +27,10 @@ void loop() {
     delay(period);
 
     // process the (possibly) counted ticks
-    Meter.tick(period);
+    Meter->tick(period);
 
     // output some measurement result
-    Serial.println("Currently " + String(Meter.getCurrentFlowrate()) + " l/min, " + String(Meter.getTotalVolume())+ " l total.");
+    Serial.println("Currently " + String(Meter->getCurrentFlowrate()) + " l/min, " + String(Meter->getTotalVolume())+ " l total.");
 
     //
     // any other code can go here

--- a/examples/Simulator/Simulator.ino
+++ b/examples/Simulator/Simulator.ino
@@ -2,16 +2,17 @@
 
 // let's provide our own sensor properties, including calibration points for error correction
 FlowSensorProperties MySensor = {60.0f, 4.5f, {1.2, 1.1, 1.05, 1, 1, 1, 1, 0.95, 0.9, 0.8}};
-
-// let's pretend there's a flow sensor connected to pin 3
-FlowMeter Meter = FlowMeter(3, MySensor);
+FlowMeter *Meter;
 
 void setup() {
     // prepare serial communication
     Serial.begin(9600);
 
+    // let's pretend there's a flow sensor connected to pin 3
+    Meter = new FlowMeter(3, MySensor);
+
     // sometimes initializing the gear generates some pulses that we should ignore
-    Meter.reset();
+    Meter->reset();
 }
 
 void loop() {
@@ -21,23 +22,23 @@ void loop() {
 
     // simulate random flow meter pulses within a random period
     for (long i = 0; i < (long) ((float) period * (float) frequency / 1000.0f); i++) {
-        Meter.count();
+        Meter->count();
     }
 
     // wait that random period
     delay(period);
 
     // process the counted ticks
-    Meter.tick(period);
+    Meter->tick(period);
 
     // output some measurement result
-    Serial.println("FlowMeter - period: " + String(Meter.getCurrentDuration() / 1000.0f, 3) + "s, " +
-                  "frequency: " + String(Meter.getCurrentFrequency(), 0) + "Hz, " +
-                  "volume: " + Meter.getCurrentVolume() + "l, " +
-                  "flow rate: " + Meter.getCurrentFlowrate() + "l/min, " +
-                  "error: " + Meter.getCurrentError() + "%, " +
-                  "total duration: " + Meter.getTotalDuration() / 1000.0f + "s, " +
-                  "total volume: " + Meter.getTotalVolume() + "l, " +
-                  "average flow rate: " + Meter.getTotalFlowrate() + "l/min, " +
-                  "average error: " + Meter.getTotalError() + "%.");
+    Serial.println("FlowMeter - period: " + String(Meter->getCurrentDuration() / 1000.0f, 3) + "s, " +
+                  "frequency: " + String(Meter->getCurrentFrequency(), 0) + "Hz, " +
+                  "volume: " + Meter->getCurrentVolume() + "l, " +
+                  "flow rate: " + Meter->getCurrentFlowrate() + "l/min, " +
+                  "error: " + Meter->getCurrentError() + "%, " +
+                  "total duration: " + Meter->getTotalDuration() / 1000.0f + "s, " +
+                  "total volume: " + Meter->getTotalVolume() + "l, " +
+                  "average flow rate: " + Meter->getTotalFlowrate() + "l/min, " +
+                  "average error: " + Meter->getTotalError() + "%.");
 }

--- a/examples/Simulator/Simulator.ino
+++ b/examples/Simulator/Simulator.ino
@@ -9,7 +9,7 @@ void setup() {
     Serial.begin(9600);
 
     // let's pretend there's a flow sensor connected to pin 3
-    Meter = new FlowMeter(3, MySensor);
+    Meter = new FlowMeter(digitalPinToInterrupt(3), MySensor);
 
     // sometimes initializing the gear generates some pulses that we should ignore
     Meter->reset();

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -61,6 +61,15 @@ void FlowMeter::count() {
     this->_currentPulses++;                                                 //!< this should be called from an interrupt service routine
 }
 
+void FlowMeter::pause() {
+    detachInterrupt(_pin);
+    this->currentPulses = 0;
+}
+
+void FlowMeter::resume() {
+    attachInterrupt(_pin, _interruptCallback, RISING);
+}
+
 void FlowMeter::reset() {
     detachInterrupt(_pin);                                                  //!< going to change interrupt variable(s)
     this->_currentPulses = 0;                                               //!< reset pulse counter

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -73,10 +73,6 @@ void FlowMeter::reset() {
     this->_currentFlowrate = 0.0f;
     this->_currentVolume = 0.0f;
     this->_currentCorrection = 0.0f;
-
-    this->_totalDuration = 0.0f;
-    this->_totalVolume = 0.0f;
-    this->_totalCorrection = 0.0f;
 }
 
 unsigned int FlowMeter::getPin() {

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -71,8 +71,8 @@ void FlowMeter::reset() {
     this->_currentFlowrate = 0.0f;
     this->_currentVolume = 0.0f;
     this->_currentCorrection = 0.0f;
+
     this->_totalDuration = 0.0f;
-    this->_totalFrequency = 0.0f;
     this->_totalVolume = 0.0f;
     this->_totalCorrection = 0.0f;
 }

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -6,11 +6,14 @@
 #include "FlowMeter.h"                                                      // https://github.com/sekdiy/FlowMeter
 #include <math.h>
 
-FlowMeter::FlowMeter(unsigned int pin, FlowSensorProperties prop) :
+FlowMeter::FlowMeter(unsigned int pin, FlowSensorProperties prop, voidFuncPtr callback, uint8_t interruptMode) :
     _pin(pin),                                                              //!< store pin number
-    _properties(prop)                                                       //!< store sensor properties
+    _properties(prop),                                                      //!< store sensor properties
+    _interruptCallback(callback),
+    _interruptMode(mode)                                            
 {
   pinMode(pin, INPUT_PULLUP);                                               //!< initialize interrupt pin as input with pullup
+  attachInterrupt(pin, _interruptCallback, _interruptMode);
 }
 
 double FlowMeter::getCurrentFlowrate() {
@@ -32,10 +35,10 @@ double FlowMeter::getTotalVolume() {
 void FlowMeter::tick(unsigned long duration) {
     /* sampling and normalisation */
     double seconds = duration / 1000.0f;                                    //!< normalised duration (in s, i.e. per 1000ms)
-    cli();                                                                  //!< going to change interrupt variable(s)
+    detachInterrupt(_pin);                                                  //!< going to change interrupt variable(s)
     double frequency = this->_currentPulses / seconds;                      //!< normalised frequency (in 1/s)
     this->_currentPulses = 0;                                               //!< reset pulse counter after successfull sampling
-    sei();                                                                  //!< done changing interrupt variable(s)
+    attachInterrupt(_pin, _interruptCallback, RISING);                        //!< done changing interrupt variable(s)
 
     /* determine current correction factor (from sensor properties) */
     unsigned int decile = floor(10.0f * frequency / (this->_properties.capacity * this->_properties.kFactor));          //!< decile of current flow relative to sensor capacity
@@ -59,9 +62,9 @@ void FlowMeter::count() {
 }
 
 void FlowMeter::reset() {
-    cli();                                                                  //!< going to change interrupt variable(s)
+    detachInterrupt(_pin);                                                  //!< going to change interrupt variable(s)
     this->_currentPulses = 0;                                               //!< reset pulse counter
-    sei();                                                                  //!< done changing interrupt variable(s)
+    attachInterrupt(_pin, _interruptCallback, RISING);                        //!< done changing interrupt variable(s)
 
     this->_currentFrequency = 0.0f;
     this->_currentDuration = 0.0f;

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -71,6 +71,10 @@ void FlowMeter::reset() {
     this->_currentFlowrate = 0.0f;
     this->_currentVolume = 0.0f;
     this->_currentCorrection = 0.0f;
+    this->_totalDuration = 0.0f;
+    this->_totalFrequency = 0.0f;
+    this->_totalVolume = 0.0f;
+    this->_totalCorrection = 0.0f;
 }
 
 unsigned int FlowMeter::getPin() {

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -10,7 +10,7 @@ FlowMeter::FlowMeter(unsigned int pin, FlowSensorProperties prop, voidFuncPtr ca
     _pin(pin),                                                              //!< store pin number
     _properties(prop),                                                      //!< store sensor properties
     _interruptCallback(callback),
-    _interruptMode(mode)                                            
+    _interruptMode(interruptMode)                                            
 {
   pinMode(pin, INPUT_PULLUP);                                               //!< initialize interrupt pin as input with pullup
   attachInterrupt(pin, _interruptCallback, _interruptMode);

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -37,10 +37,10 @@ double FlowMeter::getTotalVolume() {
 void FlowMeter::tick(unsigned long duration) {
     /* sampling and normalisation */
     double seconds = duration / 1000.0f;                                    //!< normalised duration (in s, i.e. per 1000ms)
-    detachInterrupt(_pin);                                                  //!< going to change interrupt variable(s)
+    noInterrupts();                                                         //!< going to change interrupt variable(s)
     double frequency = this->_currentPulses / seconds;                      //!< normalised frequency (in 1/s)
     this->_currentPulses = 0;                                               //!< reset pulse counter after successfull sampling
-    attachInterrupt(_pin, _interruptCallback, RISING);                        //!< done changing interrupt variable(s)
+    interrupts();                                                           //!< done changing interrupt variable(s)
 
     /* determine current correction factor (from sensor properties) */
     unsigned int decile = floor(10.0f * frequency / (this->_properties.capacity * this->_properties.kFactor));          //!< decile of current flow relative to sensor capacity
@@ -63,19 +63,10 @@ void FlowMeter::count() {
     this->_currentPulses++;                                                 //!< this should be called from an interrupt service routine
 }
 
-void FlowMeter::pause() {
-    detachInterrupt(_pin);
-    this->_currentPulses = 0;
-}
-
-void FlowMeter::resume() {
-    attachInterrupt(_pin, _interruptCallback, RISING);
-}
-
 void FlowMeter::reset() {
-    detachInterrupt(_pin);                                                  //!< going to change interrupt variable(s)
+    noInterrupts();                                                         //!< going to change interrupt variable(s)
     this->_currentPulses = 0;                                               //!< reset pulse counter
-    attachInterrupt(_pin, _interruptCallback, RISING);                        //!< done changing interrupt variable(s)
+    interrupts();                                                           //!< done changing interrupt variable(s)
 
     this->_currentFrequency = 0.0f;
     this->_currentDuration = 0.0f;

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -63,7 +63,7 @@ void FlowMeter::count() {
 
 void FlowMeter::pause() {
     detachInterrupt(_pin);
-    this->currentPulses = 0;
+    this->_currentPulses = 0;
 }
 
 void FlowMeter::resume() {

--- a/src/FlowMeter.cpp
+++ b/src/FlowMeter.cpp
@@ -6,14 +6,16 @@
 #include "FlowMeter.h"                                                      // https://github.com/sekdiy/FlowMeter
 #include <math.h>
 
-FlowMeter::FlowMeter(unsigned int pin, FlowSensorProperties prop, voidFuncPtr callback, uint8_t interruptMode) :
+FlowMeter::FlowMeter(unsigned int pin, FlowSensorProperties prop, void (*callback)(void), uint8_t interruptMode) :
     _pin(pin),                                                              //!< store pin number
     _properties(prop),                                                      //!< store sensor properties
     _interruptCallback(callback),
     _interruptMode(interruptMode)                                            
 {
   pinMode(pin, INPUT_PULLUP);                                               //!< initialize interrupt pin as input with pullup
-  attachInterrupt(pin, _interruptCallback, _interruptMode);
+
+  if (_interruptCallback != NULL)
+    attachInterrupt(pin, _interruptCallback, _interruptMode);
 }
 
 double FlowMeter::getCurrentFlowrate() {

--- a/src/FlowMeter.h
+++ b/src/FlowMeter.h
@@ -83,6 +83,8 @@ class FlowMeter {
     void tick(unsigned long duration = 1000);
     void count();                                //!< Increments the internal pulse counter. Serves as an interrupt callback routine.
     void reset();                                //!< Prepares the flow meter for a fresh measurement. Resets all current values, but not the totals.
+    void pause();
+    void resume();
 
     /*
      * setters enabling continued metering across power cycles

--- a/src/FlowMeter.h
+++ b/src/FlowMeter.h
@@ -83,8 +83,6 @@ class FlowMeter {
     void tick(unsigned long duration = 1000);
     void count();                                //!< Increments the internal pulse counter. Serves as an interrupt callback routine.
     void reset();                                //!< Prepares the flow meter for a fresh measurement. Resets all current values, but not the totals.
-    void pause();
-    void resume();
 
     /*
      * setters enabling continued metering across power cycles

--- a/src/FlowMeter.h
+++ b/src/FlowMeter.h
@@ -6,6 +6,8 @@
  * @author sekdiy (https://github.com/sekdiy/FlowMeter)
  * @date 14.07.2015 Initial release.
  * @version See git comments for changes.
+ *
+ * @todo Split up flow sensor and flow meter into different classes and files.
  */
 
 #ifndef FLOWMETER_H
@@ -42,7 +44,7 @@ class FlowMeter {
      * @param pin  The pin that the flow sensor is connected to (has to be interrupt capable, default: INT0).
      * @param prop The properties of the actual flow sensor being used (default: UncalibratedSensor).
      */
-    FlowMeter(unsigned int pin = 2, FlowSensorProperties prop = UncalibratedSensor);
+    FlowMeter(unsigned int pin = 2, FlowSensorProperties prop = UncalibratedSensor, voidFuncPtr interruptCallback = nullptr, uint8_t interruptMode = RISING);
 
     double getCurrentFlowrate();                 //!< Returns the current flow rate since last reset (in l/min).
     double getCurrentVolume();                   //!< Returns the current volume since last reset (in l).
@@ -104,6 +106,8 @@ class FlowMeter {
   protected:
     unsigned int _pin;                           //!< connection pin (has to be interrupt capable!)
     FlowSensorProperties _properties;            //!< sensor properties (including calibration data)
+    voidFuncPtr _interruptCallback;              //!< interrupt callback
+    uint8_t _interruptMode;                      //!< interrupt mode (LOW, CHANGE, RISING, FALLING, HIGH)
 
     unsigned long _currentDuration;              //!< current tick duration (convenience, in ms)
     double _currentFrequency;                    //!< current pulses per second (convenience, in 1/s)

--- a/src/FlowMeter.h
+++ b/src/FlowMeter.h
@@ -44,7 +44,7 @@ class FlowMeter {
      * @param pin  The pin that the flow sensor is connected to (has to be interrupt capable, default: INT0).
      * @param prop The properties of the actual flow sensor being used (default: UncalibratedSensor).
      */
-    FlowMeter(unsigned int pin = 2, FlowSensorProperties prop = UncalibratedSensor, voidFuncPtr interruptCallback = nullptr, uint8_t interruptMode = RISING);
+    FlowMeter(unsigned int pin = 2, FlowSensorProperties prop = UncalibratedSensor, void (*callback)(void) = NULL, uint8_t interruptMode = RISING);
 
     double getCurrentFlowrate();                 //!< Returns the current flow rate since last reset (in l/min).
     double getCurrentVolume();                   //!< Returns the current volume since last reset (in l).
@@ -108,7 +108,7 @@ class FlowMeter {
   protected:
     unsigned int _pin;                           //!< connection pin (has to be interrupt capable!)
     FlowSensorProperties _properties;            //!< sensor properties (including calibration data)
-    voidFuncPtr _interruptCallback;              //!< interrupt callback
+    void (*_interruptCallback)(void);            //!< interrupt callback
     uint8_t _interruptMode;                      //!< interrupt mode (LOW, CHANGE, RISING, FALLING, HIGH)
 
     unsigned long _currentDuration;              //!< current tick duration (convenience, in ms)


### PR DESCRIPTION
## Tackles issue #

Code doesn't compile on all Arduino platforms (those that don't have `cli()` and `sei()` functions)

## Changes being applied by this pull request

- change `cli()` and `sei()` calls to `detachInterrupt()` and `attachInterrupt()` accordingly
- add constructor options to pass in interrupt function and interrupt trigger
- adds `pause()` and `resume()` methods

## people involved

@outlandnish